### PR TITLE
Added license header to top of atHash files

### DIFF
--- a/projects/atLib/aberrantToothbrushLibrary.vcxproj
+++ b/projects/atLib/aberrantToothbrushLibrary.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="source\atGraphics.cpp" />
     <ClCompile Include="source\atGraphicsModel.cpp" />
     <ClCompile Include="source\atHardwareTexture.cpp" />
+    <ClCompile Include="source\atHash.cpp" />
     <ClCompile Include="source\atImage.cpp" />
     <ClCompile Include="source\atImageHelper.cpp" />
     <ClCompile Include="source\atInput.cpp" />
@@ -75,6 +76,7 @@
     <ClInclude Include="source\atGraphics.h" />
     <ClInclude Include="source\atGraphicsModel.h" />
     <ClInclude Include="source\atHardwareTexture.h" />
+    <ClInclude Include="source\atHash.h" />
     <ClInclude Include="source\atHashMap.h" />
     <ClInclude Include="source\atImage.h" />
     <ClInclude Include="source\atImageHelper.h" />
@@ -125,6 +127,7 @@
     <None Include="source\atAABB.inl" />
     <None Include="source\atColor.inl" />
     <None Include="source\atFilename.inl" />
+    <None Include="source\atHash.inl" />
     <None Include="source\atHashMap.inl" />
     <None Include="source\atIntersects.inl" />
     <None Include="source\atIterator.inl" />

--- a/projects/atLib/aberrantToothbrushLibrary.vcxproj.filters
+++ b/projects/atLib/aberrantToothbrushLibrary.vcxproj.filters
@@ -255,6 +255,9 @@
     <ClCompile Include="source\atGraphicsModel.cpp">
       <Filter>Source Files\Graphics\Geometry</Filter>
     </ClCompile>
+    <ClCompile Include="source\atHash.cpp">
+      <Filter>Source Files\Math</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\atAlloc.h">
@@ -425,6 +428,9 @@
     <ClInclude Include="source\atTriangle.h">
       <Filter>Header Files\Math\Geometry</Filter>
     </ClInclude>
+    <ClInclude Include="source\atHash.h">
+      <Filter>Header Files\Math</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="NatvisFile.natvis" />
@@ -477,6 +483,9 @@
     </None>
     <None Include="source\atPlane.inl">
       <Filter>Header Files\Math\Geometry</Filter>
+    </None>
+    <None Include="source\atHash.inl">
+      <Filter>Header Files\Math</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/projects/atLib/source/atAssert.cpp
+++ b/projects/atLib/source/atAssert.cpp
@@ -28,7 +28,6 @@
 
 void _atRelAssert(const bool cond, const char *message, const int64_t line, const char *file, const char *function)
 {
-  atUnused(cond, message, line, file, function);
   if (!cond)
 #ifdef _DEBUG
     if (_CrtDbgReport(_CRT_ASSERT, file, (int)line, function, message))

--- a/projects/atLib/source/atFilename.h
+++ b/projects/atLib/source/atFilename.h
@@ -61,5 +61,17 @@ protected:
 typedef atFilenameBasic<char> atFilename;
 typedef atFilenameBasic<wchar_t> atWideFilename;
 
+
+template <typename T> _atStreamRead(atFilenameBasic<T>)
+{
+  atString path;
+  int64_t ret = atStreamRead(pStream, &path);
+  pData->assign(path);
+  return ret;
+}
+
+template <typename T> _atStreamWrite(atFilenameBasic<T>) { return atStreamWrite(pStream, data.Path()); }
+
+
 #include "atFilename.inl"
 #endif

--- a/projects/atLib/source/atGraphics.h
+++ b/projects/atLib/source/atGraphics.h
@@ -118,16 +118,24 @@ template<class T> inline void atGraphics::SafeRelease(T &ref)
 // DirectX Type Description Comparison Functions
 
 bool operator==(const D3D11_SAMPLER_DESC &lhs, const D3D11_SAMPLER_DESC &rhs);
-bool operator==(const D3D11_SAMPLER_DESC & lhs, const D3D11_SAMPLER_DESC & rhs);
 bool operator==(const D3D11_BLEND_DESC & lhs, const D3D11_BLEND_DESC & rhs);
 bool operator==(const D3D11_RASTERIZER_DESC & lhs, const D3D11_RASTERIZER_DESC & rhs);
 bool operator==(const D3D11_DEPTH_STENCIL_DESC & lhs, const D3D11_DEPTH_STENCIL_DESC & rhs);
 
 bool operator!=(const D3D11_SAMPLER_DESC &lhs, const D3D11_SAMPLER_DESC &rhs);
-bool operator!=(const D3D11_SAMPLER_DESC & lhs, const D3D11_SAMPLER_DESC & rhs);
 bool operator!=(const D3D11_BLEND_DESC & lhs, const D3D11_BLEND_DESC & rhs);
 bool operator!=(const D3D11_RASTERIZER_DESC & lhs, const D3D11_RASTERIZER_DESC & rhs);
 bool operator!=(const D3D11_DEPTH_STENCIL_DESC & lhs, const D3D11_DEPTH_STENCIL_DESC & rhs);
+
+atTrivialStreamRead(D3D11_BLEND_DESC);
+atTrivialStreamRead(D3D11_SAMPLER_DESC);
+atTrivialStreamRead(D3D11_RASTERIZER_DESC);
+atTrivialStreamRead(D3D11_DEPTH_STENCIL_DESC);
+
+atTrivialStreamWrite(D3D11_BLEND_DESC);
+atTrivialStreamWrite(D3D11_SAMPLER_DESC);
+atTrivialStreamWrite(D3D11_RASTERIZER_DESC);
+atTrivialStreamWrite(D3D11_DEPTH_STENCIL_DESC);
 
 // ----------------------------------------------------------------------------------------
 #endif // _atGraphics_h__

--- a/projects/atLib/source/atHash.cpp
+++ b/projects/atLib/source/atHash.cpp
@@ -23,32 +23,35 @@
 // THE SOFTWARE.
 // -----------------------------------------------------------------------------
 
-#ifndef atHash_h__
-#define atHash_h__
+#include "atHash.h"
 
-#include "atMemoryWriter.h"
+thread_local atMemoryWriter atHash::writer;
 
-
-class atHash
+int64_t atHash::Hash(const atMemoryWriter &mem)
 {
-public:
-  static int64_t Hash(const atMemoryWriter &mem);
-  static int64_t Hash(const int64_t val);
-  static int64_t Hash(const int32_t val);
-  static int64_t Hash(const int16_t val);
-  static int64_t Hash(const int8_t val);
-  static int64_t Hash(const uint64_t val);
-  static int64_t Hash(const uint32_t val);
-  static int64_t Hash(const uint16_t val);
-  static int64_t Hash(const uint8_t val);
-  static int64_t Hash(const double val);
-  static int64_t Hash(const float val);
+  // One-at-a-Time hash
+  int64_t hash = 0;
 
-  template <typename T> static int64_t Hash(const T &o);
+  for (const uint8_t byte : mem.m_data)
+  {
+    hash += byte;
+    hash += (hash << 10);
+    hash ^= (hash >> 6);
+  }
 
-protected:
-  static thread_local atMemoryWriter writer;
-};
+  hash += (hash << 3);
+  hash += (hash >> 11);
+  hash += (hash << 15);
+  return hash;
+}
 
-#include "atHash.inl"
-#endif // atHash_h__s
+int64_t atHash::Hash(const int64_t val) { return val; }
+int64_t atHash::Hash(const int32_t val) { return (int64_t)val; }
+int64_t atHash::Hash(const int16_t val) { return (int64_t)val; }
+int64_t atHash::Hash(const int8_t val) { return (int64_t)val; }
+int64_t atHash::Hash(const uint64_t val) { return val; }
+int64_t atHash::Hash(const uint32_t val) { return (int64_t)val; }
+int64_t atHash::Hash(const uint16_t val) { return (int64_t)val; }
+int64_t atHash::Hash(const uint8_t val) { return (int64_t)val; }
+int64_t atHash::Hash(const double val) { return *(int64_t*)&val; }
+int64_t atHash::Hash(const float val) { return *(int64_t*)&val; }

--- a/projects/atLib/source/atHash.inl
+++ b/projects/atLib/source/atHash.inl
@@ -23,32 +23,9 @@
 // THE SOFTWARE.
 // -----------------------------------------------------------------------------
 
-#ifndef atHash_h__
-#define atHash_h__
-
-#include "atMemoryWriter.h"
-
-
-class atHash
+template <typename T> int64_t atHash::Hash(const T &o)
 {
-public:
-  static int64_t Hash(const atMemoryWriter &mem);
-  static int64_t Hash(const int64_t val);
-  static int64_t Hash(const int32_t val);
-  static int64_t Hash(const int16_t val);
-  static int64_t Hash(const int8_t val);
-  static int64_t Hash(const uint64_t val);
-  static int64_t Hash(const uint32_t val);
-  static int64_t Hash(const uint16_t val);
-  static int64_t Hash(const uint8_t val);
-  static int64_t Hash(const double val);
-  static int64_t Hash(const float val);
-
-  template <typename T> static int64_t Hash(const T &o);
-
-protected:
-  static thread_local atMemoryWriter writer;
-};
-
-#include "atHash.inl"
-#endif // atHash_h__s
+  writer.Clear();
+  writer.Write(o);
+  return atHash::Hash(writer);
+}

--- a/projects/atLib/source/atHashMap.h
+++ b/projects/atLib/source/atHashMap.h
@@ -32,6 +32,8 @@
 template <class Key, class Value> class atHashMap
 {
 public:
+  const int64_t m_itemCount = 16;
+
   typedef atKeyValue<Key, Value> KVP;
   typedef atVector<KVP> Bucket;
 

--- a/projects/atLib/source/atInput.cpp
+++ b/projects/atLib/source/atInput.cpp
@@ -34,7 +34,7 @@ static atVec2I s_lastMousePos;
 static atVec2F s_mouseVel;
 static atVec2I s_lockPos = { 0,0 };
 static bool s_mouseLocked = false;
-static atHashMap<HWND, bool> s_windows;
+static atHashMap<int64_t, bool> s_windows;
 
 bool s_mouseSet = false;
 
@@ -51,7 +51,7 @@ static HWND _GetFocus()
 {
   HWND focus = GetFocus();
   for (auto& kvp: s_windows)
-    if (focus == kvp.m_key)
+    if (focus == (HWND)kvp.m_key)
       return focus;
   return NULL;
 }
@@ -135,11 +135,11 @@ bool atInput::MouseMoved() { return s_mousePos != s_lastMousePos; }
 
 void atInput::RegisterWindow(HWND hWnd) 
 { 
-  s_windows.TryAdd(hWnd);
+  s_windows.TryAdd((int64_t)hWnd);
 }
 
 void atInput::UnRegisterWindow(HWND hWnd) 
 { 
-  if (s_windows.Contains(hWnd)) 
-    s_windows.Remove(hWnd); 
+  if (s_windows.Contains((int64_t)hWnd)) 
+    s_windows.Remove((int64_t)hWnd); 
 }

--- a/projects/atLib/source/atMemoryWriter.h
+++ b/projects/atLib/source/atMemoryWriter.h
@@ -21,8 +21,9 @@ public:
   bool operator!=(const atMemoryWriter &rhs);
   bool operator==(const atMemoryWriter &rhs);
 
-protected:
   atVector<uint8_t> m_data;
+  
+protected:
   int64_t m_pos = 0;
 };
 

--- a/projects/atLib/source/atOBJReader.cpp
+++ b/projects/atLib/source/atOBJReader.cpp
@@ -107,7 +107,7 @@ static void _ParseFace(char **ppSrc, const int64_t srcLen, atVector<atMesh::Tria
     {
       int64_t len = 0;
       int64_t slashIndex = 0;
-      while (atString::_find_first_not(*ppSrc, srcLen, atString::Whitespace(), pos) == pos)
+      while (atString::_find_first_not(*ppSrc, srcLen, atString::Whitespace(), pos) == pos && slashIndex <= 2)
       {
         int64_t val = atScan::Int(*ppSrc + pos, &len);
         if (len > 0)

--- a/projects/atLib/source/atVector.h
+++ b/projects/atLib/source/atVector.h
@@ -183,11 +183,9 @@ template <typename T> _atStreamRead(atVector<T>)
 {
   int64_t size = 0;
   int64_t ret = atStreamRead(pStream, &size);
-  T* pBuffer = (T*)atAlloc(sizeof(T) * size);
+  pData->resize(size);
   for (int64_t i = 0; i < size; ++i)
-    ret += atStreamRead(pStream, pBuffer + i);
-  pData->set_data(pBuffer, size, size);
-
+    ret += atStreamRead(pStream, pData->data() + i);
   return ret;
 }
 


### PR DESCRIPTION
Added atHash and implement proper hash maps
- atHashMap uses atHash to assign buckets
- huge decrease in import times using atGraphics model as this process relies heavily on the speed of atHashMap.
- remove atUnused from atAssert
- fixed bug in OBJReader which cause the reader to get stuck in a while loop